### PR TITLE
Feat/run ci on every push

### DIFF
--- a/.github/workflows/deploy-to-gh-pages.yml
+++ b/.github/workflows/deploy-to-gh-pages.yml
@@ -11,6 +11,9 @@ jobs:
       - name: Install Packages 📦
         run: yarn install --frozen-lockfile
 
+      - name: View dir structure
+        run: ls
+
       - name: Build App 🔧
         run: yarn build:prod
 

--- a/.github/workflows/deploy-to-gh-pages.yml
+++ b/.github/workflows/deploy-to-gh-pages.yml
@@ -12,6 +12,8 @@ jobs:
         id: cache-packages
         uses: actions/cache@v2
         with:
+          # to force a fresh install and skip the cache,
+          # change the version number: e.g. v1 -> v2
           key: v1-${{ hashFiles('yarn.lock') }}
           path: |
             node_modules

--- a/.github/workflows/deploy-to-gh-pages.yml
+++ b/.github/workflows/deploy-to-gh-pages.yml
@@ -15,7 +15,7 @@ jobs:
         run: yarn build
 
       - name: Deploy 🚀
-        if: ${{ github.ref_name === main }}
+        if: ${{ github.ref_name == main }}
         uses: JamesIves/github-pages-deploy-action@4.1.5
         with:
           branch: gh-pages

--- a/.github/workflows/deploy-to-gh-pages.yml
+++ b/.github/workflows/deploy-to-gh-pages.yml
@@ -15,7 +15,7 @@ jobs:
         run: yarn build
 
       - name: Deploy 🚀
-        if: ${{ github.ref_name == main }}
+        if: ${{ github.ref_name == "main" }}
         uses: JamesIves/github-pages-deploy-action@4.1.5
         with:
           branch: gh-pages

--- a/.github/workflows/deploy-to-gh-pages.yml
+++ b/.github/workflows/deploy-to-gh-pages.yml
@@ -8,10 +8,11 @@ jobs:
       - name: Checkout 🛎️
         uses: actions/checkout@v2.3.1
 
-      - name: Install and Build 🔧
-        run: |
-          yarn install
-          yarn build
+      - name: Install Packages 📦
+        run: yarn install
+
+      - name: Build App 🔧
+        run: yarn build
 
       - name: Deploy 🚀
         if: ${{ github.ref_name === main }}

--- a/.github/workflows/deploy-to-gh-pages.yml
+++ b/.github/workflows/deploy-to-gh-pages.yml
@@ -8,8 +8,8 @@ jobs:
       - name: Checkout 🛎️
         uses: actions/checkout@v2.3.1
 
-      - name: Cache Packages 💾
-        id: cache-packages
+      - name: Restore Cache 💾
+        id: restore-cache
         uses: actions/cache@v2
         with:
           # to force a fresh install and skip the cache,
@@ -20,7 +20,7 @@ jobs:
             ~/.cache/Cypress
 
       - name: Install Packages 📦
-        if: steps.cache-packages.outputs.cache-hit != 'true'
+        if: steps.restore-cache.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
 
       - name: Build App 🔧

--- a/.github/workflows/deploy-to-gh-pages.yml
+++ b/.github/workflows/deploy-to-gh-pages.yml
@@ -15,7 +15,7 @@ jobs:
         run: yarn build
 
       - name: Deploy 🚀
-        if: ${{ github.ref_name == "main" }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         uses: JamesIves/github-pages-deploy-action@4.1.5
         with:
           branch: gh-pages

--- a/.github/workflows/deploy-to-gh-pages.yml
+++ b/.github/workflows/deploy-to-gh-pages.yml
@@ -9,7 +9,7 @@ jobs:
         uses: actions/checkout@v2.3.1
 
       - name: Install Packages 📦
-        run: yarn install
+        run: yarn install --frozen-lockfile
 
       - name: Build App 🔧
         run: yarn build

--- a/.github/workflows/deploy-to-gh-pages.yml
+++ b/.github/workflows/deploy-to-gh-pages.yml
@@ -1,7 +1,4 @@
-on:
-  push:
-    branches:
-      - main
+on: push
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
@@ -17,6 +14,7 @@ jobs:
           yarn build
 
       - name: Deploy 🚀
+        if: ${{ github.ref_name === main }}
         uses: JamesIves/github-pages-deploy-action@4.1.5
         with:
           branch: gh-pages

--- a/.github/workflows/deploy-to-gh-pages.yml
+++ b/.github/workflows/deploy-to-gh-pages.yml
@@ -8,7 +8,7 @@ jobs:
       - name: Checkout 🛎️
         uses: actions/checkout@v2.3.1
 
-      - name: Cache Packages
+      - name: Cache Packages 💾
         id: cache-packages
         uses: actions/cache@v2
         with:

--- a/.github/workflows/deploy-to-gh-pages.yml
+++ b/.github/workflows/deploy-to-gh-pages.yml
@@ -9,10 +9,10 @@ jobs:
         uses: actions/checkout@v2.3.1
 
       - name: Install Packages 📦
-        run: yarn install --frozen-lockfile && yarn list
+        run: yarn install --frozen-lockfile
 
       - name: Build App 🔧
-        run: yarn build
+        run: yarn build:prod
 
       - name: Deploy 🚀
         if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/deploy-to-gh-pages.yml
+++ b/.github/workflows/deploy-to-gh-pages.yml
@@ -9,7 +9,7 @@ jobs:
         uses: actions/checkout@v2.3.1
 
       - name: Install Packages 📦
-        run: yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile && yarn list
 
       - name: Build App 🔧
         run: yarn build

--- a/.github/workflows/deploy-to-gh-pages.yml
+++ b/.github/workflows/deploy-to-gh-pages.yml
@@ -8,11 +8,18 @@ jobs:
       - name: Checkout 🛎️
         uses: actions/checkout@v2.3.1
 
-      - name: Install Packages 📦
-        run: yarn install --frozen-lockfile
+      - name: Cache Packages
+        id: cache-packages
+        uses: actions/cache@v2
+        with:
+          key: v1-${{ hashFiles('yarn.lock') }}
+          path: |
+            node_modules
+            ~/.cache/Cypress
 
-      - name: View dir structure
-        run: ls ~/.cache/
+      - name: Install Packages 📦
+        if: steps.cache-packages.outputs.cache-hit != 'true'
+        run: yarn install --frozen-lockfile
 
       - name: Build App 🔧
         run: yarn build:prod

--- a/.github/workflows/deploy-to-gh-pages.yml
+++ b/.github/workflows/deploy-to-gh-pages.yml
@@ -12,7 +12,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: View dir structure
-        run: ls
+        run: ls ~/.cache/
 
       - name: Build App 🔧
         run: yarn build:prod

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "license": "MIT",
   "scripts": {
     "build": "yarn node esbuild.config.cjs",
-    "checkTypes": "yarn tsc --noEmit",
-    "build:dev": "yarn checkTypes & yarn build",
-    "build:prod": "yarn checkTypes && yarn build",
+    "check-types": "yarn tsc --noEmit",
+    "build:dev": "yarn check-types & yarn build",
+    "build:prod": "yarn check-types && yarn build",
     "start": "http-server -c-1",
     "watch": "nodemon -e js,cjs,ts,json --ignore ./public --exec 'yarn build:dev && yarn start'",
     "e2e": "cypress open & yarn start"

--- a/package.json
+++ b/package.json
@@ -11,9 +11,7 @@
     "e2e": "cypress open & yarn start"
   },
   "dependencies": {
-    "phaser": "3.55.2"
-  },
-  "devDependencies": {
+    "phaser": "3.55.2",
     "cypress": "^9.1.0",
     "cypress-plugin-snapshots": "^1.4.4",
     "esbuild": "^0.14.1",
@@ -21,5 +19,6 @@
     "node": "^17.1.0",
     "nodemon": "^2.0.15",
     "typescript": "^4.5.2"
-  }
+  },
+  "devDependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -15,10 +15,11 @@
     "cypress": "^9.1.0",
     "cypress-plugin-snapshots": "^1.4.4",
     "esbuild": "^0.14.1",
-    "http-server": "^14.0.0",
     "node": "^17.1.0",
-    "nodemon": "^2.0.15",
     "typescript": "^4.5.2"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "http-server": "^14.0.0",
+    "nodemon": "^2.0.15"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "build": "yarn node esbuild.config.cjs",
     "checkTypes": "yarn tsc --noEmit",
-    "build:dev": "yarn build & yarn checkTypes",
-    "build:prod": "yarn build && yarn checkTypes",
+    "build:dev": "yarn checkTypes & yarn build",
+    "build:prod": "yarn checkTypes && yarn build",
     "start": "http-server -c-1",
     "watch": "nodemon -e js,cjs,ts,json --ignore ./public --exec 'yarn build:dev && yarn start'",
     "e2e": "cypress open & yarn start"

--- a/package.json
+++ b/package.json
@@ -5,9 +5,12 @@
   "author": "Jody Salt <jody.salt@wealthwizards.com>",
   "license": "MIT",
   "scripts": {
-    "build": "yarn tsc --noEmit & yarn node esbuild.config.cjs",
+    "build": "yarn node esbuild.config.cjs",
+    "checkTypes": "yarn tsc --noEmit",
+    "build:dev": "yarn build & yarn checkTypes",
+    "build:prod": "yarn build && yarn checkTypes",
     "start": "http-server -c-1",
-    "watch": "nodemon -e js,cjs,ts,json --ignore ./public --exec 'yarn build && yarn start'",
+    "watch": "nodemon -e js,cjs,ts,json --ignore ./public --exec 'yarn build:dev && yarn start'",
     "e2e": "cypress open & yarn start"
   },
   "dependencies": {


### PR DESCRIPTION
This PR:
- Runs the CI build on every push, not just on `main` -  This prevents surprise build failures when merging PRs ♼
- **Drastically** reduces CI build times by caching `node_modules` and `~/.cache/Cypress` 🏎
  -  30 second deploys if packages remain the same